### PR TITLE
Fix SSH connection timeouts during long builds

### DIFF
--- a/packages/common/src/ssh/base-client.ts
+++ b/packages/common/src/ssh/base-client.ts
@@ -149,8 +149,8 @@ export const baseSshClient = async (
       host: hostname,
       port,
       privateKey: clientPrivateKey,
-      keepaliveInterval: 15000,
-      keepaliveCountMax: 3,
+      keepaliveInterval: 60000,
+      keepaliveCountMax: 10,
       hostVerifier,
     })
   })

--- a/packages/core/src/ssh/client/index.ts
+++ b/packages/core/src/ssh/client/index.ts
@@ -20,6 +20,9 @@ export const connectSshClient = async (
         ...connectConfig.algorithms,
         compress: connectConfig.algorithms?.compress ?? ['zlib@openssh.com', 'zlib', 'none'],
       },
+      // Add keepalive options to prevent SSH timeouts during long builds
+      keepaliveInterval: 60000, // 60 seconds
+      keepaliveCountMax: 10, 
       ...connectConfig,
       debug: debug ? log.debug : undefined,
     })


### PR DESCRIPTION
## Summary
- Add SSH keepalive settings to the core SSH client to prevent timeouts during long builds
- Set keepaliveInterval to 60 seconds and keepaliveCountMax to 10 to maintain connections

## Problem
When running long builds with preevy, SSH connections would sometimes time out, resulting in errors like: \

## Solution
Added SSH keepalive settings to the SSH client used for provisioning, ensuring connections stay active during long builds without requiring client-side SSH configuration.